### PR TITLE
adding DELETE method to HttpExecutor

### DIFF
--- a/glome-http/glome-http-executor/src/main/java/space/glome/http/executor/HttpExecutor.java
+++ b/glome-http/glome-http-executor/src/main/java/space/glome/http/executor/HttpExecutor.java
@@ -143,6 +143,9 @@ public class HttpExecutor {
 				httpPut.setEntity(new ByteArrayEntity(request.getPayload()));
 				httpUriRequest = httpPut;
 				break;
+			case DELETE:
+				httpUriRequest = new HttpDelete(request.getUrl().getRaw());;
+				break;
 			default:
 				throw new Error("Method " + request.getMethod() + " not supported");
 			}


### PR DESCRIPTION
Required for regression tests.
Until now is not supported. Throws "unsupported method" Error.